### PR TITLE
docs: change docs gihub link

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -78,7 +78,7 @@ defmodule XmlBuilder.Mixfile do
       maintainers: ["Aleksei Matiushkin"],
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/am-kantox/#{@app}",
+        "GitHub" => "https://github.com/am-kantox/xml_builder",
         "Docs" => "https://hexdocs.pm/#{@app}"
       }
     ]


### PR DESCRIPTION
Summary:
When generating hex.pm pages for a package, the links field is used. That link is currently broken for this package.

Test Plan:
`mix doc`